### PR TITLE
230524 BOJ 사탕게임

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -628,11 +628,6 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/

--- a/Yennie/15810_BOJ_풍선공장.cpp
+++ b/Yennie/15810_BOJ_풍선공장.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+
+using namespace std;
+
+typedef pair<long, long> pa;
+
+int N, M;
+
+int main() 
+{
+    ios_base::sync_with_stdio(false);
+    cin.tie(0);
+
+    cin >> N >> M; // 스탭 수, 풍선 수
+    int res = 0;
+
+    priority_queue<pa, vector<pa>, greater<pa>> pq;
+
+    for (int i=0; i<N; i++) {
+        long long v;
+        cin >> v;
+        pq.push(make_pair(v, v)); // 실시간 누적 작업시간 / 스탭별 필요 작업시간
+    }
+
+    for (int i=0; i<M-1; i++){
+        long long now_time = pq.top().first;
+        long long staff_time = pq.top().second;
+
+        pq.pop();
+        pq.push(make_pair(now_time + staff_time, staff_time));
+    }
+
+    cout << pq.top().first;
+    
+    return 0;
+}

--- a/Yennie/3085_BOJ_사탕게임.cpp
+++ b/Yennie/3085_BOJ_사탕게임.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <algorithm>
+#include <string>
+
+using namespace std;
+
+int N;
+char candy_board[51][51];
+
+int return_max_candy(int dir) // 방향(행/열)
+{
+    int max_num, res = 0;
+    char now_candy;
+
+    for (int i=0; i<N; i++){
+        now_candy = dir ? candy_board[i][0] : candy_board[0][i];
+        max_num = 1;
+        for (int j=1; j<N; j++){
+            if (now_candy == (dir ? candy_board[i][j] : candy_board[j][i])) {
+                max_num++;
+            } else {
+                max_num = 1;
+            }
+            now_candy = dir ? candy_board[i][j] : candy_board[j][i];
+            res = max(res, max_num);
+        }
+    }
+
+    return res;
+}
+
+int main()
+{
+    ios_base::sync_with_stdio(false);
+    cin.tie(0);
+
+    int res = -1;
+
+    cin >> N;
+    
+    // 캔디보드 채우기
+    for (int i=0; i<N; i++){
+        for (int j=0; j<N; j++){
+            cin >> candy_board[i][j];
+        }
+    }
+
+    // 탐색
+    for (int i=0; i<N; i++){
+        for (int j=0; j<N-1; j++){
+            // 가로 swap
+            if (candy_board[i][j] != candy_board[i][j+1]) {
+                swap(candy_board[i][j], candy_board[i][j+1]);
+
+                int row_max = return_max_candy(1); // 가로 방향 체크
+                int column_max = return_max_candy(0); // 세로 방향 체크
+                res = max(res, max(row_max, column_max));
+                if (res == N) break;
+
+                // 원복
+                swap(candy_board[i][j], candy_board[i][j+1]);
+            }
+
+            // 세로 swap
+            if (candy_board[j][i] != candy_board[j+1][i]) {
+                swap(candy_board[j][i], candy_board[j+1][i]);
+
+                int row_max = return_max_candy(1); // 가로 방향 체크
+                int column_max = return_max_candy(0); // 세로 방향 체크
+                res = max(res, max(row_max, column_max));
+                if (res == N) break;
+
+                // 원복
+                swap(candy_board[j][i], candy_board[j+1][i]);
+            }
+        }
+    }
+
+    cout << res;
+}
+


### PR DESCRIPTION
## Problem Description

<br>
문제 

- [BOJ 3085 사탕게임](https://www.acmicpc.net/problem/3085)

- [BOJ 15810 풍선 공장](https://www.acmicpc.net/problem/15810)

(사탕게임)
색이 같지 않은 인접한 두 개의 사탕을 서로 자리를 바꾼 뒤, 같은 색으로 이루어져 있는 가장 긴 연속 부분 (행 or 열) 을 찾고 그 때의 총 사탕 개수를 구하는 문제

(풍선공장)
N명의 스태프가 풍선 M개를 만들 수 있는 최소 시간

## Explain Process

<br>

(사탕게임)
-  algorithm 헤더의 swap 내장 함수를 사용한다. 현재 index 기준으로 가로, 세로 기준으로 swap 한 뒤 전체 사탕 보드를 한 번 싹 훑어보면 된다.
- 최대 행 or 열 의 길이는 N이므로, 사탕 보드를 탐색하다가 max 사탕 값이 N 이면, 즉시 탐색을 종료한다.


(풍선공장)
- 우선순위 큐를 활용해 스태프들의 현재 누적 작업 시간을 구하고, 가장 최소값이 스태프에게 풍선을 불게끔 시킨다.
- 우선순위 큐가 완전이진탐색 트리 이므로 이분탐색이 된다는 점이 포인트.

### Comment
생각보다 고려해야 되는 조건이 많아서 머리가 아팠던 문제였습니다.