### PR TITLE
231011 BOJ 12865, 13164

### DIFF
--- a/JIWON/BOJ_12865_NormalBackpack.py
+++ b/JIWON/BOJ_12865_NormalBackpack.py
@@ -1,0 +1,21 @@
+import sys
+
+N, K = map(int,sys.stdin.readline().split())
+WV = [(0,0)]
+dp = [[0]*(K+1) for i in range(N+1)] #dp 생성
+
+for i in range(N):
+    W, V = map(int,sys.stdin.readline().split())
+    WV.append((W,V)) #WV[i][0]이 weight, WV[i][1]이 value값을 가짐
+
+
+for i in range(1,N+1):
+    w = WV[i][0]
+    v = WV[i][1]
+    for j in range(1,K+1):
+        if j < w :
+            dp[i][j] = dp[i-1][j]
+        else:
+            dp[i][j] = max(dp[i-1][j], v+dp[i-1][j-w])
+
+print(dp[N][K])

--- a/JIWON/BOJ_13164_HappyKindergarten.py
+++ b/JIWON/BOJ_13164_HappyKindergarten.py
@@ -1,0 +1,12 @@
+import sys
+N, K = map(int, sys.stdin.readline().split())
+kids = list(map(int, sys.stdin.readline().split()))
+
+dif = []
+
+for i in range(1,len(kids)):
+    dif.append(kids[i]-kids[i-1])
+
+dif.sort(reverse=True)
+tshirt = sum(dif[K-1:])
+print(tshirt)


### PR DESCRIPTION
12865 평범한 배낭
13164 행복 유치원

## Problem Description

<br>
- 12865 평범한 배낭: N개의 물건은 각각 무게 W와 가치 V를 갖는데, 최대 K만큼의 무게만 배낭에 넣으면서 최대의 가치 V 값을 구하는 문제
- 13164 행복유치원 : N명을 K개의 조로 나누는데 각 조의 아이들의 키 차이 값이 곧 티셔츠 제작 비용 → 비용을 최소화하는 방향으로 조를 나누는 방법을 구한다.

## Explain Process

<br>
- 12865 평범한 배낭: 입력받은 N개의 무게와 가치를 tuple 형태로 리스트에 저장하고, dp[N+1][K+1]을 생성한다. i는 1~N까지, j는 1~K까지 반복문을 통해 j 무게일 때, **1)** 현재 물건을 넣을 공간이 있는지 확인한다. 이 때, 공간이 없다면 이 전 물건(i-1)까지 넣었을 때의 가치를 dp에 저장한다. i번째 물건을 넣을 무게가 남아 있다면 **2)** 가치를 더 높이기 위해 현재의 물건을 넣는 경우(j 무게를 맞추기 위해 그만큼의 무게를 빼고 넣는 것)와 넣지 않는 경우(원래의 가치를 유지하는 것) 중에 최댓값을 선택한다. 최종 DP[N][K]에 위치하는 값이 최댓값이다.
- 13164 행복유치원 : 입력 받은 후, 각 아이의 키 차이를 리스트로 생성함. 정렬하여 가장 차이가 큰 아이들 사이를 잘라 나누는 것으로 생각 → 리스트를 내림차순으로 정렬하도록 reverse=True 사용하여 정렬하고 k-1번 나눌 수 있도록 하여 차이값을 모두 더함.

### Comment
행복유치원 - 생각보다 쉽게 해결되는 문제
평범한배낭 - DP, Knapsack 문제